### PR TITLE
I want to merge the Exercises Detail Branch with main

### DIFF
--- a/src/components/Detail.js
+++ b/src/components/Detail.js
@@ -1,0 +1,74 @@
+import React from "react";
+import { Typography, Stack, Button } from "@mui/material";
+
+import BodyPartImage from "../assets/icons/body-part.png";
+import TargetImage from "../assets/icons/target.png";
+import EquipmentImage from "../assets/icons/equipment.png";
+
+const Detail = ({ exerciseDetail }) => {
+  // Object destructuring
+  const { bodyPart, gifUrl, name, target, equipment } = exerciseDetail;
+
+  // This allows us to get the extra detail images
+  const extraDetail = [
+    {
+      icon: BodyPartImage,
+      name: bodyPart,
+    },
+    {
+      icon: TargetImage,
+      name: target,
+    },
+    {
+      icon: EquipmentImage,
+      name: equipment,
+    },
+  ];
+
+  return (
+    <Stack
+      gap="60px"
+      sx={{ flexDirection: { lg: "row" }, p: "20px", alignItems: "center" }}
+    >
+      <img src={gifUrl} alt={name} loading="lazy" className="detail-image" />
+      <Stack sx={{ gap: { lg: "35px", xs: "20px" } }}>
+        <Typography variant="h3" style={{ textTransform: "capitalize" }}>
+          {name}
+        </Typography>
+        <Typography
+          sx={{ fontSize: { lg: "24px", xs: "18px" } }}
+          color="#4F4C4C"
+          variant="h6"
+        >
+          Exercises keep you strong.{" "}
+          <span style={{ textTransform: "capitalize" }}>{name}</span> is one of
+          the best <br /> exercises to target your {target}. It will help you
+          improve your <br /> mood and gain energy.
+        </Typography>
+        {extraDetail.map((item) => (
+          <Stack key={item.name} direction="row" gap="24px" alignItems="center">
+            <Button
+              sx={{
+                background: "#FFF2DB",
+                borderRadius: "50%",
+                width: "100px",
+                height: "100px",
+              }}
+            >
+              <img
+                src={item.icon}
+                alt={bodyPart}
+                style={{ width: "50px", height: "50px" }}
+              />
+            </Button>
+            <Typography variant="h5" textTransform="capitalize">
+              {item.name}
+            </Typography>
+          </Stack>
+        ))}
+      </Stack>
+    </Stack>
+  );
+};
+
+export default Detail;

--- a/src/components/ExerciseVideos.js
+++ b/src/components/ExerciseVideos.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const ExerciseVideos = () => {
+  return <div>ExerciseVideos</div>;
+};
+
+export default ExerciseVideos;

--- a/src/components/SimilarExercises.js
+++ b/src/components/SimilarExercises.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const SimilarExercises = () => {
+  return <div>SimilarExercises</div>;
+};
+
+export default SimilarExercises;

--- a/src/pages/ExerciseDetail.js
+++ b/src/pages/ExerciseDetail.js
@@ -1,7 +1,40 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { Box } from "@mui/material";
+
+import { exerciseOptions, fetchData } from "../utils/fetchData";
+import Detail from "../components/Detail";
+import ExerciseVideos from "../components/ExerciseVideos";
+import SimilarExercises from "../components/SimilarExercises";
 
 const ExerciseDetail = () => {
-  return <div>ExerciseDetail</div>;
+  const [exerciseDetail, setExerciseDetail] = useState({});
+  const { id } = useParams();
+
+  useEffect(() => {
+    // APIs
+    const fetchExercisesData = async () => {
+      const exerciseDbUrl = "https://exercisedb.p.rapidapi.com";
+      const youTubeSearchUrl =
+        "https://youtube-search-and-download.p.rapidapi.com";
+
+      // API Calls
+      const exerciseDetailData = await fetchData(
+        `${exerciseDbUrl}/exercises/exercise/${id}`,
+        exerciseOptions
+      );
+      setExerciseDetail(exerciseDetailData);
+    };
+    fetchExercisesData();
+  }, [id]);
+
+  return (
+    <Box>
+      <Detail exerciseDetail={exerciseDetail} />
+      <ExerciseVideos />
+      <SimilarExercises />
+    </Box>
+  );
 };
 
 export default ExerciseDetail;


### PR DESCRIPTION
If a user clicks on an exercise card they will now be taken to a detail page for that exercise. As of now, the exercise name, a sample text, the GIF demonstration, and 3 relevant icons are displayed. Next is to add YouTube videos and similar exercises.